### PR TITLE
Removido referência a figura não utilizada no capítulo 15 e pequena correção numa frase do apêndice B

### DIFF
--- a/docs/15-classes-objetos.md
+++ b/docs/15-classes-objetos.md
@@ -153,8 +153,6 @@ A expressão `box.corner.x` significa “Vá ao objeto ao qual `box` se refere e
 
 A Figura 15.2 mostra o estado deste objeto. Um objeto que é um atributo de outro objeto é integrado.
 
-A Figura 10.1 mostra o diagrama de estado para cheeses, numbers e empty.
-
 ![Figura 15.2 – Diagrama de um objeto Rectangle.](https://github.com/PenseAllen/PensePython2e/raw/master/fig/tnkp_1502.png)
 <br>_Figura 15.2 – Diagrama de um objeto_ `Rectangle`.
 

--- a/docs/B-analise-algorit.md
+++ b/docs/B-analise-algorit.md
@@ -160,7 +160,7 @@ Se a sequência tiver um milhão de itens, serão necessários cerca de 20 passo
 
 A busca por bisseção pode ser muito mais rápida que a busca linear, mas é preciso que a sequência esteja em ordem, o que pode exigir trabalho extra.
 
-Há outra estrutura de dados chamada hashtable, que é até mais rápida – você pode fazer uma busca em tempo constante – e ela não exige que os itens estejam ordenados. Os dicionários do Python são implementados usando hashtables e é por isso a maior parte das operações de dicionário, incluindo o operador in, são de tempo constante.
+Há outra estrutura de dados chamada hashtable, que é até mais rápida – você pode fazer uma busca em tempo constante – e ela não exige que os itens estejam ordenados. Os dicionários do Python são implementados usando hashtables e é por isso que a maior parte das operações de dicionário, incluindo o operador in, são de tempo constante.
 
 ## B.4 - Hashtables
 


### PR DESCRIPTION
Removido referência a figura não utilizada no capítulo 15. O texto cita uma figura do capítulo 10 que não aparece no capítulo 15 e nem parece ter importância para o conteúdo abordado.

Adicionada pequena correção numa frase do apêndice B onde a ausência da palavra "que" dificultava um pouco a compreensão do texto.