### PR TITLE
Correções nos links das soluções dos exercícios

### DIFF
--- a/docs/03-funcoes.md
+++ b/docs/03-funcoes.md
@@ -542,7 +542,7 @@ do_twice(print_spam)
 
 5. Defina uma função nova chamada `do_four` que receba um objeto de função e um valor e chame a função quatro vezes, passando o valor como um parâmetro. Deve haver só duas afirmações no corpo desta função, não quatro.
 
-Solução: http://thinkpython2.com/code/do_four.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/do_four.py.
 
 
 ### Exercício 3.3
@@ -579,4 +579,5 @@ Solução: http://thinkpython2.com/code/do_four.py.
 
 2. Escreva uma função que desenhe uma grade semelhante com quatro linhas e quatro colunas.
 
-Solução: http://thinkpython2.com/code/grid.py. Crédito: Este exercício é baseado em outro apresentado por Oualline, em Practical C Programming, Third Edition, O’Reilly Media, 1997.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/grid.py.
+Crédito: Este exercício é baseado em outro apresentado por Oualline, em Practical C Programming, Third Edition, O’Reilly Media, 1997.

--- a/docs/04-caso-interface.md
+++ b/docs/04-caso-interface.md
@@ -6,7 +6,7 @@ Ele apresenta o módulo turtle, que permite criar imagens usando [_turtle graphi
 
 Se já tiver instalado o Python no seu computador, você poderá executar os exemplos. Caso não, agora é uma boa hora para instalar. Publiquei instruções no site http://tinyurl.com/thinkpython2e.
 
-Os exemplos de código deste capítulo estão disponíveis em http://thinkpython2.com/code/polygon.py.
+Os exemplos de código deste capítulo estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/polygon.py.
 
 ## 4.1 - Módulo turtle
 
@@ -376,7 +376,7 @@ Se as precondições forem satisfeitas e as pós-condições não forem, o probl
 
 ### Exercício 4.1
 
-Baixe o código deste capítulo no site http://thinkpython2.com/code/polygon.py.
+Baixe o código deste capítulo no site https://github.com/AllenDowney/ThinkPython2/raw/master/code/polygon.py.
 
 1. Desenhe um diagrama da pilha que mostre o estado do programa enquanto executa circle (bob, radius). Você pode fazer a aritmética à mão ou acrescentar instruções print ao código.
 
@@ -389,7 +389,7 @@ Escreva um conjunto de funções adequadamente geral que possa desenhar flores c
 ![Figura 4.1 – Flores de tartaruga.](https://github.com/PenseAllen/PensePython2e/raw/master/fig/tnkp_0401.png)
 <br>_Figura 4.1 – Flores de tartaruga._
 
-Solução: http://thinkpython2.com/code/flower.py, também exige http://thinkpython2.com/code/polygon.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/flower.py, também exige https://github.com/AllenDowney/ThinkPython2/raw/master/code/polygon.py.
 
 ### Exercício 4.3
 
@@ -398,16 +398,16 @@ Escreva um conjunto de funções adequadamente geral que possa desenhar formas c
 ![Figura 4.2 – Tortas de tartaruga.](https://github.com/PenseAllen/PensePython2e/raw/master/fig/tnkp_0402.png)
 <br>_Figura 4.2 – Tortas de tartaruga._
 
-Solução: http://thinkpython2.com/code/pie.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/pie.py.
 
 
 ### Exercício 4.4
 
 As letras do alfabeto podem ser construídas a partir de um número moderado de elementos básicos, como linhas verticais e horizontais e algumas curvas. Crie um alfabeto que possa ser desenhado com um número mínimo de elementos básicos e então escreva funções que desenhem as letras.
 
-Você deve escrever uma função para cada letra, com os nomes draw\_a, draw\_b etc., e colocar suas funções em um arquivo chamado letters.py. Você pode baixar uma “máquina de escrever de turtle” no site http://thinkpython2.com/code/typewriter.py para ajudar a testar o seu código.
+Você deve escrever uma função para cada letra, com os nomes draw\_a, draw\_b etc., e colocar suas funções em um arquivo chamado letters.py. Você pode baixar uma “máquina de escrever de turtle” no site https://github.com/AllenDowney/ThinkPython2/raw/master/code/typewriter.py para ajudar a testar o seu código.
 
-Você pode ver uma solução no site http://thinkpython2.com/code/letters.py; ela também exige http://thinkpython2.com/code/polygon.py.
+Você pode ver uma solução no site https://github.com/AllenDowney/ThinkPython2/raw/master/code/letters.py; ela também exige https://github.com/AllenDowney/ThinkPython2/raw/master/code/polygon.py.
 
 ### Exercício 4.5
 

--- a/docs/05-cond-recur.md
+++ b/docs/05-cond-recur.md
@@ -543,6 +543,6 @@ A exceção é se x for menor que 3: neste caso, você pode desenhar apenas uma 
 
 2. Escreva uma função chamada snowflake que desenhe três curvas de Koch para fazer o traçado de um floco de neve.
 
-        Solução: http://thinkpython2.com/code/koch.py.
+        Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/koch.py.
 
 3. A curva de Koch pode ser generalizada de vários modos. Veja exemplos em http://en.wikipedia.org/wiki/Koch\_snowflake e implemente o seu favorito.

--- a/docs/06-funcoes-result.md
+++ b/docs/06-funcoes-result.md
@@ -492,7 +492,7 @@ A função de Ackermann, A(m, n), é definida assim:
 
 Veja http://en.wikipedia.org/wiki/Ackermann_function. Escreva uma função denominada ack que avalie a função de Ackermann. Use a sua função para avaliar `ack(3, 4)`, cujo resultado deve ser 125. O que acontece para valores maiores de m e n?
 
-Solução: http://thinkpython2.com/code/ackermann.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/ackermann.py.
 
 ### Exercício 6.3
 
@@ -515,7 +515,7 @@ Veremos como funcionam no Capítulo 8.
 
 2. Escreva uma função chamada `is_palindrome` que receba uma string como argumento e retorne True se for um palíndromo e False se não for. Lembre-se de que você pode usar a função integrada len para verificar o comprimento de uma string.
 
-Solução: http://thinkpython2.com/code/palindrome_soln.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/palindrome_soln.py.
 
 ### Exercício 6.4
 

--- a/docs/09-caso-palavras.md
+++ b/docs/09-caso-palavras.md
@@ -4,7 +4,7 @@ Este capítulo apresenta o segundo estudo de caso que envolve solucionar quebra-
 
 ## 9.1 - Leitura de listas de palavras
 
-Para os exercícios deste capítulo vamos usar uma lista de palavras em inglês. Há muitas listas de palavras disponíveis na internet, mas a mais conveniente ao nosso propósito é uma das listas de palavras disponibilizadas em domínio público por Grady Ward como parte do projeto lexical Moby (ver http://wikipedia.org/wiki/Moby\_Project). É uma lista de 113.809 palavras cruzadas oficiais; isto é, as palavras que se consideram válidas em quebra-cabeças de palavras cruzadas e outros jogos de palavras. Na coleção Moby, o nome do arquivo é 113809of.fic; você pode baixar uma cópia, com um nome mais simples como words.txt, de http://thinkpython2.com/code/words.txt.
+Para os exercícios deste capítulo vamos usar uma lista de palavras em inglês. Há muitas listas de palavras disponíveis na internet, mas a mais conveniente ao nosso propósito é uma das listas de palavras disponibilizadas em domínio público por Grady Ward como parte do projeto lexical Moby (ver http://wikipedia.org/wiki/Moby\_Project). É uma lista de 113.809 palavras cruzadas oficiais; isto é, as palavras que se consideram válidas em quebra-cabeças de palavras cruzadas e outros jogos de palavras. Na coleção Moby, o nome do arquivo é 113809of.fic; você pode baixar uma cópia, com um nome mais simples como words.txt, de https://github.com/AllenDowney/ThinkPython2/raw/master/code/words.txt.
 
 Este arquivo está em texto simples, então você pode abri-lo com um editor de texto, mas também pode lê-lo no Python. A função integrada open recebe o nome do arquivo como um parâmetro e retorna um objeto de arquivo que você pode usar para ler o arquivo.
 
@@ -255,7 +255,7 @@ Dê uma palavra com três letras duplas consecutivas. Vou dar exemplos de palavr
 
 Escreva um programa que a encontre.
 
-Solução: http://thinkpython2.com/code/cartalk1.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/cartalk1.py.
 
 ### Exercício 9.8
 
@@ -271,7 +271,7 @@ Aqui está outro quebra-cabeça do programa Car Talk (http://www.cartalk.com/con
 
 Escreva um programa Python que teste todos os números de seis dígitos e imprima qualquer número que satisfaça essas condições.
 
-Solução: http://thinkpython2.com/code/cartalk2.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/cartalk2.py.
 
 ### Exercício 9.9
 

--- a/docs/10-listas.md
+++ b/docs/10-listas.md
@@ -639,7 +639,7 @@ O uso descuidado de listas (e de outros objetos mutáveis) pode levar a longas h
 
 ## 10.15 - Exercícios
 
-Você pode baixar as soluções para estes exercícios em http://thinkpython2.com/code/list\_exercises.py.
+Você pode baixar as soluções para estes exercícios em https://github.com/AllenDowney/ThinkPython2/raw/master/code/list\_exercises.py.
 
 ### Exercício 10.1
 
@@ -707,13 +707,13 @@ Este exercício pertence ao assim chamado Paradoxo de aniversário, sobre o qual
 
 Se há 23 alunos na sua sala, quais são as chances de dois deles fazerem aniversário no mesmo dia? Você pode estimar esta probabilidade gerando amostras aleatórias de 23 dias de aniversário e verificando as correspondências. Dica: você pode gerar aniversários aleatórios com a função randint no módulo random.
 
-Se quiser, você pode baixar minha solução em http://thinkpython2.com/code/birthday.py.
+Se quiser, você pode baixar minha solução em https://github.com/AllenDowney/ThinkPython2/raw/master/code/birthday.py.
 
 ### Exercício 10.9
 
 Escreva uma função que leia o arquivo words.txt e construa uma lista com um elemento por palavra. Escreva duas versões desta função, uma usando o método append e outra usando a expressão `t = t + [x]`. Qual leva mais tempo para ser executada? Por quê?
 
-Solução: http://thinkpython2.com/code/wordlist.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/wordlist.py.
 
 
 ### Exercício 10.10
@@ -728,19 +728,19 @@ Escreva uma função chamada in\_bisect que receba uma lista ordenada, um valor-
 
 Ou você pode ler a documentação do módulo bisect e usá-lo!
 
-Solução: http://thinkpython2.com/code/inlist.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/inlist.py.
 
 ### Exercício 10.11
 
 Duas palavras são um “par inverso” se uma for o contrário da outra. Escreva um programa que encontre todos os pares inversos na lista de palavras.
 
-Solução: http://thinkpython2.com/code/reverse_pair.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/reverse_pair.py.
 
 ### Exercício 10.12
 
 Duas palavras “interligam-se” quando, ao tomarmos letras alternadas de cada uma, formamos uma palavra nova. Por exemplo, “shoe” e “cold” interligam-se para formar “schooled”.
 
-Solução: http://thinkpython2.com/code/interlock.py. Crédito: este exercício foi inspirado por um exemplo em http://puzzlers.org.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/interlock.py. Crédito: este exercício foi inspirado por um exemplo em http://puzzlers.org.
 
 1. Escreva um programa que encontre todos os pares de palavras que se interligam. Dica: não enumere todos os pares!
 

--- a/docs/11-dicionarios.md
+++ b/docs/11-dicionarios.md
@@ -504,13 +504,13 @@ Se fez o Exercício 10.10, você pode comparar a velocidade desta implementaçã
 
 Leia a documentação do método de dicionário setdefault e use-o para escrever uma versão mais concisa de invert\_dict.
 
-Solução: http://thinkpython2.com/code/invert_dict.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/invert_dict.py.
 
 ### Exercício 11.3
 
 Memorize a função de Ackermann do Exercício 6.2 e veja se a memorização permite avaliar a função com argumentos maiores. Dica: não.
 
-Solução: http://thinkpython2.com/code/ackermann_memo.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/ackermann_memo.py.
 
 ### Exercício 11.4
 
@@ -518,7 +518,7 @@ Se fez o Exercício 10.7, você já tem uma função chamada has\_duplicates, qu
 
 Use um dicionário para escrever uma versão mais rápida e simples de has\_duplicates.
 
-Solução: http://thinkpython2.com/code/has_duplicates.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/has_duplicates.py.
 
 ### Exercício 11.5
 
@@ -526,7 +526,7 @@ Duas palavras são “pares rotacionados” se for possível rotacionar um deles
 
 Escreva um programa que leia uma lista de palavras e encontre todos os pares rotacionados.
 
-Solução: http://thinkpython2.com/code/rotate_pairs.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/rotate_pairs.py.
 
 ### Exercício 11.6
 
@@ -540,8 +540,8 @@ Mas há pelo menos uma palavra que Dan e eu conhecemos, que produz dois homófon
 
 Você pode usar o dicionário do Exercício 11.1 para verificar se uma string está na lista de palavras.
 
-Para verificar se duas palavras são homófonas, você pode usar o Dicionário de pronúncia CMU. Ele pode ser baixado em http://www.speech.cs.cmu.edu/cgi-bin/cmudict ou em http://thinkpython2.com/code/c06d. Você também pode baixar http://thinkpy thon2.com/code/pronounce.py, que tem uma função chamada `read_dictionary`, que lê o dicionário de pronúncia e retorna um dicionário de Python que mapeia cada palavra a uma string que descreve sua pronúncia primária.
+Para verificar se duas palavras são homófonas, você pode usar o Dicionário de pronúncia CMU. Ele pode ser baixado em http://www.speech.cs.cmu.edu/cgi-bin/cmudict ou em https://github.com/AllenDowney/ThinkPython2/raw/master/code/c06d. Você também pode baixar http://thinkpy thon2.com/code/pronounce.py, que tem uma função chamada `read_dictionary`, que lê o dicionário de pronúncia e retorna um dicionário de Python que mapeia cada palavra a uma string que descreve sua pronúncia primária.
 
 Escreva um programa que liste todas as palavras que resolvem o quebra-cabeça.
 
-Solução: http://thinkpython2.com/code/homophone.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/homophone.py.

--- a/docs/12-tuplas.md
+++ b/docs/12-tuplas.md
@@ -395,7 +395,7 @@ Como tuplas são imutáveis, elas não fornecem métodos como `sort` e `reverse`
 
 As listas, os dicionários e as tuplas são exemplos de estruturas de dados; neste capítulo estamos começando a ver estruturas de dados compostas, como as listas de tuplas ou dicionários que contêm tuplas como chaves e listas como valores. As estruturas de dados compostas são úteis, mas são propensas ao que chamo de erros de forma; isto é, erros causados quando uma estrutura de dados tem o tipo, tamanho ou estrutura incorretos. Por exemplo, se você estiver esperando uma lista com um número inteiro e eu der apenas o número inteiro (não em uma lista), não vai funcionar.
 
-Para ajudar a depurar esses tipos de erro, escrevi um módulo chamado `structshape`, que fornece uma função, também chamada `structshape`, que recebe qualquer tipo de estrutura de dados como argumento e retorna uma string, que resume sua forma. Você pode baixá-la em http://thinkpython2.com/code/structshape.py.
+Para ajudar a depurar esses tipos de erro, escrevi um módulo chamado `structshape`, que fornece uma função, também chamada `structshape`, que recebe qualquer tipo de estrutura de dados como argumento e retorna uma string, que resume sua forma. Você pode baixá-la em https://github.com/AllenDowney/ThinkPython2/raw/master/code/structshape.py.
 
 Aqui está o resultado de uma lista simples:
 
@@ -475,7 +475,7 @@ Se estiver com problemas para monitorar suas estruturas de dados, o `structshape
 
 Escreva uma função chamada `most_frequent` que receba uma string e exiba as letras em ordem decrescente de frequência. Encontre amostras de texto de vários idiomas diferentes e veja como a frequência das letras varia entre os idiomas. Compare seus resultados com as tabelas em http://en.wikipedia.org/wiki/Letter_frequencies.
 
-Solução: http://thinkpython2.com/code/most_frequent.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/most_frequent.py.
 
 ### Exercício 12.2
 
@@ -498,13 +498,13 @@ Mais anagramas!
 
 3. No Scrabble, um “bingo” é quando você joga todas as sete peças na sua estante, junto com uma peça no tabuleiro, para formar uma palavra de oito letras. Que coleção de oito letras forma o maior número possível de bingos? Dica: há sete.
 
-Solução: http://thinkpython2.com/code/anagram_sets.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/anagram_sets.py.
 
 ### Exercício 12.3
 
 Duas palavras formam um “par de metátese” se você puder transformar uma na outra trocando duas letras, por exemplo, “converse” e “conserve”. Escreva um programa que descubra todos os pares de metátese no dicionário. Dica: não teste todos os pares de palavras e não teste todas as trocas possíveis.
 
-Solução: http://thinkpython2.com/code/metathesis.py. Crédito: este exercício foi inspirado por um exemplo em http://puzzlers.org.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/metathesis.py. Crédito: este exercício foi inspirado por um exemplo em http://puzzlers.org.
 
 ### Exercício 12.4
 
@@ -528,4 +528,4 @@ Este exercício é um pouco mais desafiador que a maioria, então aqui estão al
 
 4. Para melhorar o desempenho do seu programa, você pode querer memorizar as palavras conhecidas por serem redutíveis.
 
-Solução: http://thinkpython2.com/code/reducible.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/reducible.py.

--- a/docs/13-caso-estruturas.md
+++ b/docs/13-caso-estruturas.md
@@ -96,7 +96,7 @@ sua função deve retornar 'a' com a probabilidade de 2/3 e 'b' com a probabilid
 
 ## 13.3 - Histograma de palavras
 
-É uma boa ideia tentar fazer os exercícios anteriores antes de continuar. Você pode baixar minha solução em http://thinkpython2.com/code/analyze_book1.py. Também vai precisar de http://thinkpython2.com/code/emma.txt.
+É uma boa ideia tentar fazer os exercícios anteriores antes de continuar. Você pode baixar minha solução em https://github.com/AllenDowney/ThinkPython2/raw/master/code/analyze_book1.py. Também vai precisar de https://github.com/AllenDowney/ThinkPython2/raw/master/code/emma.txt.
 
 Aqui está um programa que lê um arquivo e constrói um histograma das palavras no arquivo:
 
@@ -271,7 +271,7 @@ O Python fornece uma estrutura de dados chamada `set`, que fornece muitas opera�
 
 Escreva um programa que use a subtração de conjuntos para encontrar palavras no livro que não estão na lista de palavras.
 
-Solução: http://thinkpython2.com/code/analyze_book2.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/analyze_book2.py.
 
 ## 13.7 - Palavras aleatórias
 
@@ -303,7 +303,7 @@ Uma alternativa é:
 
 Escreva um programa que use este algoritmo para escolher uma palavra aleatória do livro.
 
-Solução: http://thinkpython2.com/code/analyze_book3.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/analyze_book3.py.
 
 ## 13.8 - Análise de Markov
 
@@ -356,7 +356,7 @@ __c)__ Uma vez que o seu programa esteja funcionando, você pode querer tentar u
 
 Crédito: este estudo de caso é baseado em um exemplo de Kernighan and Pike, The Practice of Programming, Addison-Wesley, 1999.
 
-É uma boa ideia tentar fazer este exercício antes de continuar; depois você pode baixar a minha solução em http://thinkpython2.com/code/markov.py. Também vai precisar de http://thinkpython2.com/code/emma.txt.
+É uma boa ideia tentar fazer este exercício antes de continuar; depois você pode baixar a minha solução em https://github.com/AllenDowney/ThinkPython2/raw/master/code/markov.py. Também vai precisar de https://github.com/AllenDowney/ThinkPython2/raw/master/code/emma.txt.
 
 ## 13.9 - Estruturas de dados
 
@@ -484,4 +484,4 @@ Se você traçar o log de f contra o log de r, terá uma linha reta com uma elev
 
 Escreva um programa que leia um texto em um arquivo, conte as frequências das palavras e exiba uma linha para cada palavra, em ordem descendente da frequência, com log de f e log de r. Use o programa gráfico de sua escolha para traçar os resultados e verifique se formam uma linha reta. Você pode estimar o valor de s?
 
-Solução: http://thinkpython2.com/code/zipf.py. Para executar a minha solução, você vai precisar do módulo de gráficos `matplotlib`. Se você instalou o Anaconda, já tem o `matplotlib`; se não tiver, é preciso instalá-lo.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/zipf.py. Para executar a minha solução, você vai precisar do módulo de gráficos `matplotlib`. Se você instalou o Anaconda, já tem o `matplotlib`; se não tiver, é preciso instalá-lo.

--- a/docs/14-arquivos.md
+++ b/docs/14-arquivos.md
@@ -170,7 +170,7 @@ def walk(dirname):
 
 `os.path.join` recebe um diretório e um nome de arquivo e os une em um caminho completo.
 
-O módulo `os` fornece uma função chamada `walk`, que é semelhante, só que mais versátil. Como exercício, leia a documentação e use-a para exibir os nomes dos arquivos em um diretório dado e seus subdiretórios. Você pode baixar minha solução em http://thinkpython2.com/code/walk.py.
+O módulo `os` fornece uma função chamada `walk`, que é semelhante, só que mais versátil. Como exercício, leia a documentação e use-a para exibir os nomes dos arquivos em um diretório dado e seus subdiretórios. Você pode baixar minha solução em https://github.com/AllenDowney/ThinkPython2/raw/master/code/walk.py.
 
 ## 14.5 - Captura de exceções
 
@@ -479,15 +479,15 @@ Escreva uma função chamada sed que receba como argumentos uma string-padrão, 
 
 Se ocorrer um erro durante a abertura, leitura, escrita ou fechamento dos arquivos, seu programa deve capturar a exceção, exibir uma mensagem de erro e encerrar.
 
-Solução: http://thinkpython2.com/code/sed.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/sed.py.
 
 ### Exercício 14.2
 
-Se você baixar minha solução do Exercício 12.2 em http://thinkpython2.com/code/anagram_sets.py, verá que ela cria um dicionário que mapeia uma string ordenada de letras à lista de palavras que podem ser soletradas com aquelas letras. Por exemplo, `'opst'` mapeia à lista `['opts', 'post', 'pots', 'spot', 'stop', 'tops']`.
+Se você baixar minha solução do Exercício 12.2 em https://github.com/AllenDowney/ThinkPython2/raw/master/code/anagram_sets.py, verá que ela cria um dicionário que mapeia uma string ordenada de letras à lista de palavras que podem ser soletradas com aquelas letras. Por exemplo, `'opst'` mapeia à lista `['opts', 'post', 'pots', 'spot', 'stop', 'tops']`.
 
 Escreva um módulo que importe `anagram_sets` e forneça duas novas funções: `store_anagrams` deve guardar o dicionário de anagramas em uma “prateleira” (objeto criado pelo módulo `sheve`); `read_anagrams` deve procurar uma palavra e devolver uma lista dos seus anagramas.
 
-Solução: http://thinkpython2.com/code/anagram_db.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/anagram_db.py.
 
 ### Exercício 14.3
 
@@ -499,4 +499,4 @@ Em uma grande coleção de arquivos MP3 pode haver mais de uma cópia da mesma m
 
 3. Para conferir o resultado, você pode usar o comando Unix `diff`.
 
-Solução: http://thinkpython2.com/code/find\_duplicates.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/find\_duplicates.py.

--- a/docs/15-classes-objetos.md
+++ b/docs/15-classes-objetos.md
@@ -2,7 +2,7 @@
 
 A esta altura você já sabe como usar funções para organizar código e tipos integrados para organizar dados. O próximo passo é aprender “programação orientada a objeto”, que usa tipos definidos pelos programadores para organizar tanto o código quanto os dados. A programação orientada a objeto é um tópico abrangente; será preciso passar por alguns capítulos para abordar o tema.
 
-Os exemplos de código deste capítulo estão disponíveis em http://thinkpython2.com/code/Point1.py; as soluções para os exercícios estão disponíveis em http://thinkpython2.com/code/Point1_soln.py.
+Os exemplos de código deste capítulo estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Point1.py; as soluções para os exercícios estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Point1_soln.py.
 
 ## 15.1 - Tipos definidos pelos programadores
 
@@ -364,7 +364,7 @@ Essa abordagem pode facilitar a escrita de funções que atuam com tipos diferen
 
 5. Escreva uma função denominada `rect_circle_overlap`, que tome um `Circle` e um Rectangle e retorne `True`, se algum dos cantos do retângulo cair dentro do círculo. Ou, em uma versão mais desafiadora, retorne `True` se alguma parte do retângulo cair dentro do círculo.
 
-Solução: http://thinkpython2.com/code/Circle.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/Circle.py.
 
 ### Exercício 15.2
 

--- a/docs/16-classes-funcoes.md
+++ b/docs/16-classes-funcoes.md
@@ -2,7 +2,7 @@
 
 Agora que sabemos como criar tipos, o próximo passo deve ser escrever funções que recebam objetos definidos pelo programador como parâmetros e os retornem como resultados. Neste capítulo também vou apresentar o “estilo funcional de programação” e dois novos planos de desenvolvimento de programas.
 
-Os exemplos de código deste capítulo estão disponíveis em http://thinkpython2.com/code/Time1.py. As soluções para os exercícios estão em http://thinkpython2.com/code/Time1\_soln.py.
+Os exemplos de código deste capítulo estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time1.py. As soluções para os exercícios estão em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time1\_soln.py.
 
 ## 16.1 - Time
 
@@ -238,7 +238,7 @@ Instruções assert são úteis porque distinguem o código que lida com condiç
 
 ## 16.7 - Exercícios
 
-Os exemplos de código deste capítulo estão disponíveis em http://thinkpython2.com/code/Time1.py; as soluções para os exercícios estão disponíveis em http://thinkpython2.com/code/Time1_soln.py.
+Os exemplos de código deste capítulo estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time1.py; as soluções para os exercícios estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time1_soln.py.
 
 ### Exercício 16.1
 

--- a/docs/17-classes-metodos.md
+++ b/docs/17-classes-metodos.md
@@ -2,7 +2,7 @@
 
 Embora estejamos usando alguns recursos de orientação a objeto do Python, os programas dos dois últimos capítulos não são realmente orientados a objeto, porque não representam as relações entre os tipos definidos pelo programador e as funções que os produzem. O próximo passo é transformar essas funções em métodos que tornem as relações claras.
 
-Os exemplos de código deste capítulo estão disponíveis em http://thinkpython2.com/code/Time2.py e as soluções para os exercícios estão em http://thinkpython2.com/code/Point2_soln.py.
+Os exemplos de código deste capítulo estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time2.py e as soluções para os exercícios estão em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Point2_soln.py.
 
 ## 17.1 - Recursos de orientação a objeto
 
@@ -448,9 +448,9 @@ A função integrada getattr recebe um objeto e um nome de atributo (como uma st
 
 ### Exercício 17.1
 
-Baixe o código deste capítulo em http://thinkpython2.com/code/Time2.py. Altere os atributos de Time para que um número inteiro único represente os segundos decorridos desde a meia-noite. Então altere os métodos (e a função int\_to\_time) para funcionar com a nova implementação. Você não deve modificar o código de teste em main. Ao terminar, a saída deve ser a mesma que antes.
+Baixe o código deste capítulo em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time2.py. Altere os atributos de Time para que um número inteiro único represente os segundos decorridos desde a meia-noite. Então altere os métodos (e a função int\_to\_time) para funcionar com a nova implementação. Você não deve modificar o código de teste em main. Ao terminar, a saída deve ser a mesma que antes.
 
-Solução: http://thinkpython2.com/code/Time2_soln.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/Time2_soln.py.
 
 ### Exercício 17.2
 
@@ -464,6 +464,6 @@ Este exercício é uma história com moral sobre um dos erros mais comuns e dif�
 
 Teste o seu código criando dois objetos Kangaroo, atribuindo-os a variáveis chamadas kanga e roo, e então acrescentando roo ao conteúdo da bolsa de kanga.
 
-Baixe http://thinkpython2.com/code/BadKangaroo.py. Ele contém uma solução para o problema anterior com um defeito bem grande e bem feio. Encontre e corrija o defeito.
+Baixe https://github.com/AllenDowney/ThinkPython2/raw/master/code/BadKangaroo.py. Ele contém uma solução para o problema anterior com um defeito bem grande e bem feio. Encontre e corrija o defeito.
 
-Se não conseguir achar a solução, você pode baixar http://thinkpython2.com/code/GoodKangaroo.py, que explica o problema e demonstra uma solução.
+Se não conseguir achar a solução, você pode baixar https://github.com/AllenDowney/ThinkPython2/raw/master/code/GoodKangaroo.py, que explica o problema e demonstra uma solução.

--- a/docs/18-heranca.md
+++ b/docs/18-heranca.md
@@ -4,7 +4,7 @@ O termo mais associado com a programação orientada a objeto é herança. A her
 
 Se você não joga pôquer, pode ler sobre ele em http://en.wikipedia.org/wiki/Poker, mas não é necessário; vou dizer tudo o que precisa saber para os exercícios.
 
-Os exemplos de código deste capítulo estão disponíveis em http://thinkpython2.com/code/Card.py.
+Os exemplos de código deste capítulo estão disponíveis em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Card.py.
 
 ## 18.1 - Objetos Card
 
@@ -327,7 +327,7 @@ Os capítulos anteriores demonstram um plano de desenvolvimento que poderíamos 
 
 Mas, às vezes, é menos óbvio quais objetos você precisa e como eles devem interagir. Nesse caso é necessário um plano de desenvolvimento diferente. Da mesma forma em que descobrimos interfaces de função por encapsulamento e generalização, podemos descobrir interfaces de classe por encapsulamento de dados.
 
-A análise de Markov, de “Análise de Markov”, na página 200, apresenta um bom exemplo. Se baixar o meu código em http://thinkpython2.com/code/markov.py, você vai ver que ele usa duas variáveis globais – suffix\_map e prefix – que são lidas e escritas a partir de várias funções.
+A análise de Markov, de “Análise de Markov”, na página 200, apresenta um bom exemplo. Se baixar o meu código em https://github.com/AllenDowney/ThinkPython2/raw/master/code/markov.py, você vai ver que ele usa duas variáveis globais – suffix\_map e prefix – que são lidas e escritas a partir de várias funções.
 
 ```python
 suffix_map = {}
@@ -373,9 +373,9 @@ Este exemplo sugere um plano de desenvolvimento para projetar objetos e métodos
 
 4. Transforme as funções associadas em métodos da nova classe.
 
-Como exercício, baixe o meu código de Markov de http://thinkpython2.com/code/markov.py e siga os passos descritos acima para encapsular as variáveis globais como atributos de uma nova classe chamada Markov.
+Como exercício, baixe o meu código de Markov de https://github.com/AllenDowney/ThinkPython2/raw/master/code/markov.py e siga os passos descritos acima para encapsular as variáveis globais como atributos de uma nova classe chamada Markov.
 
-Solução: http://thinkpython2.com/code/Markov.py (observe o M maiúsculo).
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/markov2.py (observe o 2 no nome do arquivo).
 
 ## 18.10 - Depuração
 
@@ -535,4 +535,4 @@ A meta desses exercícios é estimar a probabilidade de ter estas várias mãos.
 
 6. Exiba uma tabela das classificações e suas probabilidades. Execute seu programa com números cada vez maiores de mãos até que os valores de saída convirjam a um grau razoável de exatidão. Compare seus resultados com os valores em http://en.wikipedia.org/wiki/Hand_rankings.
 
-Solução: http://thinkpython2.com/code/PokerHandSoln.py.
+Solução: https://github.com/AllenDowney/ThinkPython2/raw/master/code/PokerHandSoln.py.

--- a/docs/18-heranca.md
+++ b/docs/18-heranca.md
@@ -519,11 +519,11 @@ A seguir, as mãos possíveis no pôquer, em ordem crescente de valor e ordem de
 
 A meta desses exercícios é estimar a probabilidade de ter estas várias mãos.
 
-1. Baixe os seguintes arquivos de http://thinkpython2.com/code:
+1. Baixe os seguintes arquivos:
 
- * `Card.py`: Versão completa das classes Card, Deck e Hand deste capítulo.
+ * [`Card.py`](https://github.com/AllenDowney/ThinkPython2/raw/master/code/Card.py): Versão completa das classes Card, Deck e Hand deste capítulo.
 
- * `PokerHand.py`: Uma implementação incompleta de uma classe que representa uma mão de pôquer e código para testá-la.
+ * [`PokerHand.py`](https://github.com/AllenDowney/ThinkPython2/raw/master/code/PokerHand.py): Uma implementação incompleta de uma classe que representa uma mão de pôquer e código para testá-la.
 
 2. Se executar PokerHand.py, você verá que o programa cria mãos de pôquer com 7 cartas e verifica se alguma delas contém um flush. Leia este código com atenção antes de continuar.
 

--- a/docs/19-extra.md
+++ b/docs/19-extra.md
@@ -318,7 +318,7 @@ A nova lista, que estamos chamando de t, também é adicionada ao dicionário. E
 defaultdict(<class 'list'>, {'new key': ['new value']})
 ```
 
-Se estiver fazendo um dicionário de listas, você pode escrever um código mais simples usando defaultdict. Na minha solução para o Exercício 12.2, que você pode ver em http://thinkpython2.com/code/anagram\_sets.py, faço um dicionário que mapeia uma string organizada de letras a uma lista de palavras que pode ser soletrada com essas letras. Por exemplo, 'opst' mapeia para a lista `['opts', 'post', 'pots', 'spot', 'stop', 'tops']`.
+Se estiver fazendo um dicionário de listas, você pode escrever um código mais simples usando defaultdict. Na minha solução para o Exercício 12.2, que você pode ver em https://github.com/AllenDowney/ThinkPython2/raw/master/code/anagram\_sets.py, faço um dicionário que mapeia uma string organizada de letras a uma lista de palavras que pode ser soletrada com essas letras. Por exemplo, 'opst' mapeia para a lista `['opts', 'post', 'pots', 'spot', 'stop', 'tops']`.
 
 Aqui está o código original:
 
@@ -361,7 +361,7 @@ def all_anagrams(filename):
     return d
 ```
 
-A minha solução para o Exercício 18.3, que você pode baixar em http://thinkpython2.com/code/PokerHandSoln.py, usa setdefault na função `has_straightflush`. O problema dessa solução é criar um objeto Hand cada vez que passa pelo loop, seja ele necessário ou não. Como exercício, reescreva-a usando um defaultdict.
+A minha solução para o Exercício 18.3, que você pode baixar em https://github.com/AllenDowney/ThinkPython2/raw/master/code/PokerHandSoln.py, usa setdefault na função `has_straightflush`. O problema dessa solução é criar um objeto Hand cada vez que passa pelo loop, seja ele necessário ou não. Como exercício, reescreva-a usando um defaultdict.
 
 ## 19.8 - Tuplas nomeadas
 

--- a/docs/B-analise-algorit.md
+++ b/docs/B-analise-algorit.md
@@ -287,7 +287,7 @@ O trabalho extra de redispersão aparece como uma sequência de torres cada vez 
 
 Uma característica importante deste algoritmo é que quando alteramos o tamanho da HashTable, ela cresce geometricamente; isto é, multiplicamos o tamanho por uma constante. Se você aumentar o tamanho aritmeticamente – somando um número fixo de cada vez – o tempo médio por add é linear.
 
-Você pode baixar minha implementação de `HashMap` em http://thinkpython2.com/code/Map.py, mas lembre-se de que não há razão para usá-la; se quiser um mapa, basta usar um dicionário do Python.
+Você pode baixar minha implementação de `HashMap` em https://github.com/AllenDowney/ThinkPython2/raw/master/code/Map.py, mas lembre-se de que não há razão para usá-la; se quiser um mapa, basta usar um dicionário do Python.
 
 ## B.5 - Glossário
 


### PR DESCRIPTION
Enquanto lia a versão online, percebi que o site thinkpython2.com não existe mais, o que faz todos os links para as soluções dos exercícios estarem inválidos. Para piorar, o pseudo-site para onde aponta hoje o domínio acende o alerta de malware do Avast.

Por isso, apontei todos os links para apontarem para as versões raw do repositório original do Allen Downey. Testei todos eles para garantir que estejam corretos. Alterei apenas os arquivos do diretório _docs_.

**_Se esse problema com o site original for temporário, ignore esse pull request. Prometo não ficar triste._**

-----

Duas alterações dignas de nota, ambas no capítulo 18:

- "Baixe os seguintes arquivos de `http://thinkpython2.com/code`": optei por tirar o link explícito dessa linha e colocar links nos nomes dos dois arquivos, logo abaixo
- O link para a solução do Markov apontava para Markov.py e chamava atenção para a letra maiúscula no nome do arquivo. No entanto, no repositório do Allen o arquivo está como markov2.py. Corrigi o link e o texto.